### PR TITLE
`ValidatedInputInterface::getValidatedInput()` throws exception when bject is not validated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Yii Validating Hydrator Change Log
 
-## 1.0.1 under development
+## 2.0.0 under development
 
-- no changes in this release.
+- Chg #17: Throws `LogicException` on call `ValidatedInputInterface::getValidatedInput()` method when object is not
+  validated (@vjik)
 
 ## 1.0.0 February 02, 2024
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,16 @@
+# Upgrading Instructions for Yii Validating Hydrator
+
+## Upgrade from 1.x to 2.x
+
+If you use `ValidatedInputInterface::getValidatedInput()` on non-validated inputs or form models, wrap it to
+`try ... catch`:
+
+```php
+$result = $input->getValidatedInput();
+// ↓
+try {
+    $result = $input->getValidatedInput();
+} catch (LogicException) {
+    $result = null;
+}
+```

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,7 +2,7 @@
 
 ## Upgrade from 1.x to 2.x
 
-If you use `ValidatedInputInterface::getValidatedInput()` on non-validated inputs or form models, wrap it to
+If you use `ValidatedInputInterface::getValidatedInput()` on non-validated inputs or form models, wrap it with
 `try ... catch`:
 
 ```php

--- a/src/ValidatedInputInterface.php
+++ b/src/ValidatedInputInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Hydrator\Validator;
 
+use LogicException;
 use Yiisoft\Validator\PostValidationHookInterface;
 use Yiisoft\Validator\Result;
 
@@ -18,7 +19,9 @@ interface ValidatedInputInterface extends PostValidationHookInterface
     /**
      * Returns validation result.
      *
-     * @return Result|null Validation result.
+     * @return Result Validation result.
+     *
+     * @throws LogicException When validation result is not set.
      */
-    public function getValidationResult(): ?Result;
+    public function getValidationResult(): Result;
 }

--- a/src/ValidatedInputInterface.php
+++ b/src/ValidatedInputInterface.php
@@ -19,9 +19,8 @@ interface ValidatedInputInterface extends PostValidationHookInterface
     /**
      * Returns validation result.
      *
-     * @return Result Validation result.
-     *
      * @throws LogicException When validation result is not set.
+     * @return Result Validation result.
      */
     public function getValidationResult(): Result;
 }

--- a/src/ValidatedInputTrait.php
+++ b/src/ValidatedInputTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Hydrator\Validator;
 
+use LogicException;
 use Yiisoft\Hydrator\Attribute\SkipHydration;
 use Yiisoft\Validator\Result;
 
@@ -23,8 +24,12 @@ trait ValidatedInputTrait
         $this->validationResult = $result;
     }
 
-    public function getValidationResult(): ?Result
+    public function getValidationResult(): Result
     {
+        if (empty($this->validationResult)) {
+            throw new LogicException('Validation result is not set.');
+        }
+
         return $this->validationResult;
     }
 }

--- a/tests/ValidatedInputTraitTest.php
+++ b/tests/ValidatedInputTraitTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Hydrator\Validator\Tests;
+
+use LogicException;
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Hydrator\Validator\Tests\Support\Object\SimpleInput;
+
+final class ValidatedInputTraitTest extends TestCase
+{
+    public function testNotValidate(): void
+    {
+        $input = new SimpleInput();
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Validation result is not set.');
+        $input->getValidationResult();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
